### PR TITLE
Build the URL of the streaming platform when possible

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -3,6 +3,7 @@ require 'pry'
 require 'icalendar'
 
 require_relative './fetcher'
+require_relative './stream_url_builder'
 
 File.write('db.json', '{}') unless File.exist?('db.json')
 local_db = JSON.parse(File.read('db.json'))
@@ -24,7 +25,7 @@ local_db.each_value do |event|
       e.dtend = Icalendar::Values::DateTime.new(Time.parse(stream['endAt']))
       e.summary = stream['title']
       e.description = "Day #{i + 1} of #{event['name']}"
-      e.location = stream['type']
+      e.location = StreamUrlBuilder.build(stream['type'], stream['channel'])
     end
   end
 end

--- a/stream_url_builder.rb
+++ b/stream_url_builder.rb
@@ -1,0 +1,16 @@
+class StreamUrlBuilder
+  class << self
+    def build(platform, channel_code)
+      case platform
+      when 'twitch'
+        "https://www.twitch.tv/#{channel_code}"
+      when 'youtube'
+        "https://www.youtube.com/channel/#{channel_code}"
+      when 'kick'
+        "https://kick.com/#{channel_code}"
+      else
+        platform
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

We want to make it easier to follow the stream. Thus, we are configuring the location as the streaming link.