### PR TITLE
Generate a consistent UUID for events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '3.2.2'
 
 source "https://rubygems.org"
 
+gem 'activesupport', '~> 7.1.3'
 gem 'httparty'
 gem 'pry'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    drb (2.2.0)
+      ruby2_keywords
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     icalendar (2.10.1)
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
@@ -13,7 +31,9 @@ GEM
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    minitest (5.22.2)
     multi_xml (0.6.0)
+    mutex_m (0.2.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -39,12 +59,16 @@ GEM
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7.1.3)
   httparty
   icalendar
   pry


### PR DESCRIPTION
## What

We want to avoid the UID property of the events being generated every time the script runs. We are generating a consistent UUID using a fixed namespace and the numeric ID of the event from the source.