### PR TITLE
Commit changes if either db or calendar has changed

### DIFF
--- a/.github/workflows/auto-refresh.yml
+++ b/.github/workflows/auto-refresh.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Commit and push changes
         run: |
           echo "Branch name is ${{ steps.extract_branch.outputs.branch }}"
-          if ! git diff --quiet db.json; then
+          if ! git diff --quiet db.json events.ical; then
               git config --local user.email "automation@bustikiller.com"
               git config --local user.name "Automation user"
               git add db.json events.ical


### PR DESCRIPTION
## What

Sometimes we make changes to the code that are reflected in the calendar, even though not in the DB. We need to re-generate the calendar even if the DB has not changed.