### PR TITLE
Store the event URL in both the URL and location fields

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -43,7 +43,7 @@ JSON.parse(File.read('db.json')).each_value do |event|
       e.dtstamp = Icalendar::Values::DateTime.new(Time.parse(event['updatedAt']))
       e.summary = stream['title']
       e.description = "Day #{i + 1} of #{event['name']}"
-      e.url = StreamUrlBuilder.build(stream['type'], stream['channel'])
+      e.url = e.location = StreamUrlBuilder.build(stream['type'], stream['channel'])
     end
   end
 end


### PR DESCRIPTION
## What

Some calendar clients do not support the `url` property, so we are back using the location.

See https://github.com/nextcloud/calendar/issues/2895